### PR TITLE
Add gitignore for WoW Lua project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# IDE/editor folders
+.vscode/
+.idea/
+
+# OS junk files
+.DS_Store
+Thumbs.db
+
+# Backup and temporary files
+*.bak
+*.tmp
+*~
+*.swp
+*.swo
+
+# Compiled Lua
+*.luac
+
+# Build/packaging artifacts
+*.zip
+pkg/
+dist/
+release/
+.pkgmeta
+pkgmeta
+
+# WoW specific
+*.toc.bak
+*.lua.bak
+


### PR DESCRIPTION
## Summary
- add `.gitignore` with typical patterns for a World of Warcraft Lua addon project

## Testing
- `# no tests present`

------
https://chatgpt.com/codex/tasks/task_e_685dce04aaf08331b5ff61c130990ade